### PR TITLE
5: Fix dispose

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "most-from-event",
   "description": "Node events for most.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Sergey Samokhov <hi@hoichi.io> (github.com/hoichi)",
   "bugs": {
     "url": "https://github.com/mostjs-community/from-event/issues"

--- a/src/index.js
+++ b/src/index.js
@@ -5,20 +5,16 @@ import { currentTime } from '@most/scheduler'
 
 // fromEvent :: (Emitter emt, Event e) => String -> emt -> Stream e
 const fromEvent = (event, emitter) =>
-  new FromEvent(event, emitter, 'addListener')
+  FromEvent(event, emitter, 'addListener')
 
 const fromEventPrepended = (event, emitter) =>
-  new FromEvent(event, emitter, 'prependListener')
+  FromEvent(event, emitter, 'prependListener')
 
-class FromEvent {
-  constructor (event, emitter, method) {
-    this.event = event
-    this.emitter = emitter
-    this.method = method
-  }
+function FromEvent (event, emitter, method) {
+  return { run }
 
-  run (sink, scheduler) {
-    this.emitter[this.method](this.event, send)
+  function run (sink, scheduler) {
+    emitter[method](event, send)
 
     return { dispose }
 
@@ -27,7 +23,7 @@ class FromEvent {
     }
 
     function dispose () {
-      this.emitter.removeListener(this.event, send)
+      emitter.removeListener(event, send)
     }
   }
 }


### PR DESCRIPTION
1. Fixed the `dispose` method losing `this` and throwing (https://github.com/mostjs-community/from-event/issues/5)
2. Got rid of `this` altogether in favor of closures